### PR TITLE
Fixed dask/multiprocessing interference with matplotlib

### DIFF
--- a/ogindia/txfunc.py
+++ b/ogindia/txfunc.py
@@ -121,8 +121,8 @@ def gen_3Dscatters_hist(df, s, t, output_dir):
     ax.set_xlabel('Total labor income')
     ax.set_ylabel('Total capital income')
     ax.set_zlabel('Marginal Tax Rate, Labor Inc.)')
-    plt.title("MTR labor income Income, Lab. Inc., and Cap. Inc., Age="
-              + str(s) + ", Year=" + str(t))
+    plt.title('MTR labor income Income, Lab. Inc., and Cap. Inc., ' +
+              'Age=' + str(s) + ', Year=' + str(t))
     filename = ("MTRx_Age_" + str(s) + "_Year_" + str(t) + "_data.png")
     fullpath = os.path.join(output_dir, filename)
     fig.savefig(fullpath, bbox_inches='tight')

--- a/ogindia/txfunc.py
+++ b/ogindia/txfunc.py
@@ -18,6 +18,7 @@ from dask import compute, delayed
 import dask.multiprocessing
 import pickle
 import matplotlib
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 from mpl_toolkits.mplot3d import Axes3D
@@ -1049,7 +1050,7 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
         if age_specific:
             print("year=", t, "Age=", s)
             df = data[data['Age'] == s]
-            PopPct_age[s-min_age] = \
+            PopPct_age[s - min_age] = \
                 df['Weights'].sum() / TotPop_yr
 
         else:
@@ -1364,7 +1365,7 @@ def tax_func_estimate(
     AvgMTRx = np.zeros(BW)
     AvgMTRy = np.zeros(BW)
     TotPop_yr = np.zeros(BW)
-    PopPct_age = np.zeros((s_max-s_min+1, BW))
+    PopPct_age = np.zeros((s_max - s_min + 1, BW))
 
     # '''
     # --------------------------------------------------------------------
@@ -1380,7 +1381,7 @@ def tax_func_estimate(
     # '''
     start_time = time.time()
     cur_path = os.path.split(os.path.abspath(__file__))[0]
-    output_dir = os.path.join(cur_path, "OUTPUT", "TaxFunctions")
+    output_dir = os.path.join(cur_path, 'OUTPUT', 'TaxFunctions')
     if not os.access(output_dir, os.F_OK):
         os.makedirs(output_dir)
 


### PR DESCRIPTION
This PR fixes an error in the `txfunc.py` module in which setting `graph_est=True` creates the following error.

```
The process has forked and you cannot use this CoreFoundation
functionality safely. You MUST exec().
```

This seems to be an issue with `dask` and/or `dask.multiprocessing` interacting with `matplotlib`, and this error might be specific to Mac OS X operating system. I found some helpful GitHub threads [here](https://github.com/spacetelescope/PyFITS/issues/38) and [here](https://stackoverflow.com/questions/2512225/matplotlib-plots-not-showing-up-in-mac-osx). The solution is to change the default backend for Matplotlib to 'agg'.

I simply placed `matplotlib.use('agg')` under the `import matplotlib` line.

My test of the following code successfully saved all tax function estimation plots in the `OUTPUT/TaxFunctions/` folder.

```python
dict_params=txfunc.tax_func_estimate(4, 80, 21, 100, start_year=2020,
    baseline=True, analytical_mtrs=True, tax_func_type='GS', age_specific=False,
    reform={}, data=None, client=None, num_workers=1, graph_est=True)  
```
