### PR TITLE
Add *.ipynb_checkpoints* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ envs/
 *.egg-info/
 */dask-worker-space/*
 *micro_data_*.pkl
+
+# Ignore Jupyter notebook utility files
+*.ipynb_checkpoints*


### PR DESCRIPTION
@jdebacker , I just wanted to sneak this update to the `.gitignore` file with your PR. This PR just adds `*.ipynb_checkpoints*` to the end of the `.gitignore` file so that including Jupyter notebooks in the future doesn't leave any unnecessary administrative files behind.